### PR TITLE
Implement support for multiple documents

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,10 @@ YAML for XP Framework ChangeLog
 
 ## ?.?.? / ????-??-??
 
+## 5.2.0 / 2019-07-07
+
+* Merge PR #6: Implement support for multiple documents - @thekid
+
 ## 5.1.0 / 2019-07-07
 
 * Added support for `!!binary` tag, see https://yaml.org/type/binary.html

--- a/README.md
+++ b/README.md
@@ -38,3 +38,18 @@ Inputs
 * `org.yaml.FileInput(io.File|string $in)` - Use file instance or a file name
 * `org.yaml.ReaderInput(io.streams.TextReader $in)` - Reads from a text reader
 * `org.yaml.StringInput(string $in)` - Input from a string
+
+Multiple documents
+------------------
+
+YAML sources can contain more than one document. The `parse()` method will only parse the first (or only) document. To retrieve all documents in a given input, use the iterator returned by `documents()` instead.
+
+```php
+use org\yaml\{YamlParser, FileInput};
+use util\cmd\Console;
+
+$parser= new YamlParser();
+foreach ($parser->documents(new FileInput('objects.yml') as $i => $document) {
+  Console::writeLine('Document #', $i, ': ', $document);
+}
+```

--- a/src/main/php/org/yaml/YamlParser.class.php
+++ b/src/main/php/org/yaml/YamlParser.class.php
@@ -16,9 +16,7 @@ class YamlParser {
    */
   public function valueOf($reader, $value, $level= 0) {
     if (null === $value) {
-      do {
-        if (null === ($line= $reader->nextLine())) return null;  // EOF
-      } while ('---' === $line);
+      if (null === ($line= $reader->nextLine())) return null;
 
       // Check whether the next line at same or lesser indentation level. This
       // means we have a line like "key:\n" which means we're encountering an 
@@ -40,6 +38,8 @@ class YamlParser {
         } else if ('#' === $line{$p}) {
           continue;
         } else if ($p < $spaces) {
+          break;
+        } else if ('---' === $line || '...' === $line) {
           break;
         }
 
@@ -128,7 +128,7 @@ class YamlParser {
   }
 
   /**
-   * Parse a given input source
+   * Parse a given input source, using the first (or only) document only
    *
    * @param  org.yaml.Input $reader
    * @param  int $level
@@ -142,8 +142,39 @@ class YamlParser {
     do {
       $line= $reader->nextLine();
     } while ('' !== $line && '%' === $line{0});
-    $reader->resetLine($line);
 
-    return $this->valueOf($reader, null, 0);
+    // Skip over first document start
+    if ('---' !== $line) {
+      $reader->resetLine($line);
+    }
+
+    return $this->valueOf($reader, null, $level);
+  }
+
+  /**
+   * Parse a given input source, returning all documents
+   *
+   * @param  org.yaml.Input $reader
+   * @param  int $level
+   * @return iterable
+   */
+  public function documents($reader, $level= 0) {
+    $this->identifiers= [];
+    $reader->rewind();
+
+    // Check for identifiers, e.g. `%YAML 1.2`
+    do {
+      $line= $reader->nextLine();
+    } while ('' !== $line && '%' === $line{0});
+
+    // If the first line is "---", we have a multi-document YAML source
+    if ('---' === $line) {
+      do {
+        yield $this->valueOf($reader, null, $level);
+      } while ('---' === $reader->nextLine());
+    } else {
+      $reader->resetLine($line);
+      yield $this->valueOf($reader, null, $level);
+    }
   }
 }

--- a/src/main/php/org/yaml/YamlParser.class.php
+++ b/src/main/php/org/yaml/YamlParser.class.php
@@ -165,7 +165,7 @@ class YamlParser {
 
     // Check for identifiers, e.g. `%YAML 1.2`
     do {
-      $line= $reader->nextLine();
+      if (null === ($line= $reader->nextLine())) return;
     } while ('' !== $line && '%' === $line{0});
 
     // If the first line is "---", we have a multi-document YAML source

--- a/src/main/php/org/yaml/YamlParser.class.php
+++ b/src/main/php/org/yaml/YamlParser.class.php
@@ -154,6 +154,7 @@ class YamlParser {
   /**
    * Parse a given input source, returning all documents
    *
+   * @see    https://yaml.org/spec/1.2/spec.html#id2800132
    * @param  org.yaml.Input $reader
    * @param  int $level
    * @return iterable
@@ -171,7 +172,14 @@ class YamlParser {
     if ('---' === $line) {
       do {
         yield $this->valueOf($reader, null, $level);
-      } while ('---' === $reader->nextLine());
+
+        $line= $reader->nextLine();
+        if ('...' === $line) {
+          do {
+            if (null === ($line= $reader->nextLine())) break 2;
+          } while ('' !== $line && '%' === $line{0});
+        }
+      } while ('---' === $line);
     } else {
       $reader->resetLine($line);
       yield $this->valueOf($reader, null, $level);

--- a/src/main/php/org/yaml/YamlParser.class.php
+++ b/src/main/php/org/yaml/YamlParser.class.php
@@ -68,7 +68,7 @@ class YamlParser {
 
       } while (null !== ($line= $reader->nextLine()));
       $reader->resetLine($line);
-      return $r;
+      return $r ?: null;
     } else if ('&' === $value{0}) {
       if (false === ($o= strpos($value, ' '))) {
         $id= rtrim(substr($value, 1, strcspn($value, '#') - 1));

--- a/src/test/php/org/yaml/unittest/DocumentsTest.class.php
+++ b/src/test/php/org/yaml/unittest/DocumentsTest.class.php
@@ -17,7 +17,7 @@ class DocumentsTest extends TestCase {
 
   #[@test]
   public function empty_document() {
-    $this->assertEquals([[]], iterator_to_array($this->documents(
+    $this->assertEquals([null], iterator_to_array($this->documents(
       "---\n".
       "...\n"
     )));

--- a/src/test/php/org/yaml/unittest/DocumentsTest.class.php
+++ b/src/test/php/org/yaml/unittest/DocumentsTest.class.php
@@ -56,6 +56,21 @@ class DocumentsTest extends TestCase {
   }
 
   #[@test]
+  public function empty_document_between() {
+    $this->assertEquals([['A', 'B'], null, ['C', 'D']], iterator_to_array($this->documents(
+      "---\n".
+      "- A\n".
+      "- B\n".
+      "---\n".
+      "...\n".
+      "---\n".
+      "- C\n".
+      "- D\n".
+      "...\n"
+    )));
+  }
+
+  #[@test]
   public function directives() {
     $this->assertEquals([['A', 'B'], ['C', 'D']], iterator_to_array($this->documents(
       "%YAML 1.2\n".

--- a/src/test/php/org/yaml/unittest/DocumentsTest.class.php
+++ b/src/test/php/org/yaml/unittest/DocumentsTest.class.php
@@ -11,6 +11,11 @@ class DocumentsTest extends TestCase {
   }
 
   #[@test]
+  public function empty_input() {
+    $this->assertEquals([], iterator_to_array($this->documents('')));
+  }
+
+  #[@test]
   public function empty_document() {
     $this->assertEquals([[]], iterator_to_array($this->documents(
       "---\n".

--- a/src/test/php/org/yaml/unittest/DocumentsTest.class.php
+++ b/src/test/php/org/yaml/unittest/DocumentsTest.class.php
@@ -1,0 +1,52 @@
+<?php namespace org\yaml\unittest;
+
+use org\yaml\StringInput;
+use org\yaml\YamlParser;
+use unittest\TestCase;
+
+class DocumentsTest extends TestCase {
+
+  private function documents($str) {
+    return (new YamlParser())->documents(new StringInput($str));
+  }
+
+  #[@test]
+  public function empty_document() {
+    $this->assertEquals([[]], iterator_to_array($this->documents(
+      "---\n".
+      "...\n"
+    )));
+  }
+
+  #[@test]
+  public function single_document() {
+    $this->assertEquals([['A', 'B']], iterator_to_array($this->documents(
+      "---\n".
+      "- A\n".
+      "- B\n".
+      "...\n"
+    )));
+  }
+
+  #[@test]
+  public function single_document_ended_by_eof() {
+    $this->assertEquals([['A', 'B']], iterator_to_array($this->documents(
+      "---\n".
+      "- A\n".
+      "- B\n"
+    )));
+  }
+
+  #[@test]
+  public function multiple_documents() {
+    $this->assertEquals([['A', 'B'], ['C', 'D']], iterator_to_array($this->documents(
+      "---\n".
+      "- A\n".
+      "- B\n".
+      "---\n".
+      "- C\n".
+      "- D\n".
+      "...\n"
+    )));
+  }
+}

--- a/src/test/php/org/yaml/unittest/DocumentsTest.class.php
+++ b/src/test/php/org/yaml/unittest/DocumentsTest.class.php
@@ -49,4 +49,20 @@ class DocumentsTest extends TestCase {
       "...\n"
     )));
   }
+
+  #[@test]
+  public function directives() {
+    $this->assertEquals([['A', 'B'], ['C', 'D']], iterator_to_array($this->documents(
+      "%YAML 1.2\n".
+      "---\n".
+      "- A\n".
+      "- B\n".
+      "...\n".
+      "%YAML 1.2\n".
+      "---\n".
+      "- C\n".
+      "- D\n".
+      "...\n"
+    )));
+  }
 }

--- a/src/test/php/org/yaml/unittest/YamlParserTest.class.php
+++ b/src/test/php/org/yaml/unittest/YamlParserTest.class.php
@@ -14,12 +14,12 @@ class YamlParserTest extends AbstractYamlParserTest {
 
   #[@test]
   public function parse_empty() {
-    $this->assertEquals(null, $this->parse(''));
+    $this->assertNull($this->parse(''));
   }
 
   #[@test, @values(["\n", "\n\n", " \n \n", "  \n\n"])]
   public function parse_lines($value) {
-    $this->assertEquals([], $this->parse($value));
+    $this->assertNull($this->parse($value));
   }
 
   #[@test, @values(["key: value", "key: value\n"])]
@@ -34,7 +34,7 @@ class YamlParserTest extends AbstractYamlParserTest {
 
   #[@test]
   public function parse_yaml_directive() {
-    $this->assertEquals(null, $this->parse('%YAML 1.2'));
+    $this->assertNull($this->parse('%YAML 1.2'));
   }
 
   #[@test]
@@ -194,22 +194,22 @@ class YamlParserTest extends AbstractYamlParserTest {
 
   #[@test]
   public function comment() {
-    $this->assertEquals([], $this->parse('# Comments are ignored'));
+    $this->assertNull($this->parse('# Comments are ignored'));
   }
 
   #[@test]
   public function indented_comment() {
-    $this->assertEquals([], $this->parse('  # Comments are ignored'));
+    $this->assertNull($this->parse('  # Comments are ignored'));
   }
 
   #[@test]
   public function comments() {
-    $this->assertEquals([], $this->parse("# Line 1\n# Line 2\n"));
+    $this->assertNull($this->parse("# Line 1\n# Line 2\n"));
   }
 
   #[@test]
   public function comments_and_whitespace() {
-    $this->assertEquals([], $this->parse("# Line 1\n\n# Line 3\n"));
+    $this->assertNull($this->parse("# Line 1\n\n# Line 3\n"));
   }
 
   #[@test, @values(['key: value # A value', 'key: value        # A value'])]


### PR DESCRIPTION
## Documents

Core to YAML is the concept of documents. A document is not just a separate file in this case. Instead, think of a document as just a chunk of YAML. You can have multiple documents in a single stream of YAML, if each one is separated by ''---'', like:

```
---
document: this is doc 1
---
document: this is doc 2
...
```

*(Quoted from http://jessenoller.com/blog/2009/04/13/yaml-aint-markup-language-completely-different)*

## Functionality

Instead of using `parse()`, which will parse only the first (or only) document in a given input source, the `documents()` method will return an iterator over all documents.

```php
use org\yaml\{YamlParser, FileInput};
use util\cmd\Console;

$parser= new YamlParser(new FileInput($argv[0]));
foreach ($parser->documents() as $i => $document) {
  Console::writeLine('Document #', $i, ': ', $document);
}
```

Documents will be lazily parsed - multiple documents may have been completely yielded when a parse error occurs on a subsequent part of the file.