### PR TITLE
Allow passing in identifiers

### DIFF
--- a/src/main/php/org/yaml/Input.class.php
+++ b/src/main/php/org/yaml/Input.class.php
@@ -230,6 +230,12 @@ abstract class Input {
       $offset= strlen($in);
       $in.= $this->nextLine();
       return $this->token($in, $offset, $end);
+    } else if ('*' === $c) {
+      $offset+= 1;
+      $p= strcspn($in, $end, $offset);
+      $literal= trim(substr($in, $offset, $p));
+      $offset+= strlen($literal);
+      return ['*', $literal];
     } else if ('[' === $c) {
       $offset++;
       $r= [];

--- a/src/main/php/org/yaml/YamlParser.class.php
+++ b/src/main/php/org/yaml/YamlParser.class.php
@@ -7,23 +7,6 @@ class YamlParser {
   private $identifiers= [];
 
   /**
-   * Returns an identifier. Throws an exception if the identifier is unknown.
-   *
-   * @param  string $id
-   * @return var
-   * @throws lang.IllegalArgumentException
-   */
-  public function identifier($id) {
-    if (isset($this->identifiers[$id])) return $this->identifiers[$id];
-
-    throw new IllegalArgumentException(sprintf(
-      'Unresolved reference "%s", have [%s]',
-      $id,
-      $this->identifiers ? '"'.implode('", "', array_keys($this->identifiers)).'"' : ''
-    ));
-  }
-
-  /**
    * Parse a value
    *
    * @param  org.yaml.Input $reader
@@ -115,7 +98,6 @@ class YamlParser {
       case 'binary': return new Bytes(base64_decode($token[1]));
       case 'literal': return $token[1];
       case 'null': return null;
-      case '*': return $this->identifier($token[1]);
       case 'seq': {
         $r= [];
         foreach ($token[1] as $value) {
@@ -130,6 +112,14 @@ class YamlParser {
         }
         return $r;
       }
+      case '*':
+        $id= $token[1];
+        if (isset($this->identifiers[$id])) return $this->identifiers[$id];
+        throw new IllegalArgumentException(sprintf(
+          'Unresolved reference "%s", have [%s]',
+          $id,
+          $this->identifiers ? '"'.implode('", "', array_keys($this->identifiers)).'"' : ''
+        ));
       default: throw new IllegalArgumentException('Unknown tag "'.$token[0].'"');
     }
   }

--- a/src/main/php/org/yaml/YamlParser.class.php
+++ b/src/main/php/org/yaml/YamlParser.class.php
@@ -48,6 +48,7 @@ class YamlParser {
         // "- one: two\n  three: four"
         if ('-' === $line[$spaces]) {
           $key= $id++;
+
           if (!strpos('*&', $line[$spaces + 2] ?? '-') && strpos($line, ': ')) {
             $reader->resetLine(str_repeat(' ', $spaces + 2).substr($line, $spaces + 2));
             $r[$key]= $this->valueOf($reader, null, $spaces);
@@ -112,7 +113,7 @@ class YamlParser {
         }
         return $r;
       }
-      case '*':
+      case '*': {
         $id= $token[1];
         if (isset($this->identifiers[$id])) return $this->identifiers[$id];
         throw new IllegalArgumentException(sprintf(
@@ -120,6 +121,7 @@ class YamlParser {
           $id,
           $this->identifiers ? '"'.implode('", "', array_keys($this->identifiers)).'"' : ''
         ));
+      }
       default: throw new IllegalArgumentException('Unknown tag "'.$token[0].'"');
     }
   }

--- a/src/main/php/org/yaml/YamlParser.class.php
+++ b/src/main/php/org/yaml/YamlParser.class.php
@@ -65,7 +65,7 @@ class YamlParser {
         // "- one: two\n  three: four"
         if ('-' === $line[$spaces]) {
           $key= $id++;
-          if (!strpos('*&', $line[$spaces + 2] ?? '') && strpos($line, ': ')) {
+          if (!strpos('*&', $line[$spaces + 2] ?? '-') && strpos($line, ': ')) {
             $reader->resetLine(str_repeat(' ', $spaces + 2).substr($line, $spaces + 2));
             $r[$key]= $this->valueOf($reader, null, $spaces);
           } else if ($spaces + 2 > $l) {

--- a/src/main/php/org/yaml/YamlParser.class.php
+++ b/src/main/php/org/yaml/YamlParser.class.php
@@ -81,9 +81,9 @@ class YamlParser {
       $id= rtrim(substr($value, 1, strcspn($value, '#') - 1));
       if (!isset($this->identifiers[$id])) {
         throw new IllegalArgumentException(sprintf(
-          'Unresolved reference "%s", have ["%s"]',
+          'Unresolved reference "%s", have [%s]',
           $id,
-          implode('", "', array_keys($this->identifiers))
+          $this->identifiers ? '"'.implode('", "', array_keys($this->identifiers)).'"' : ''
         ));
       }
       return $this->identifiers[$id];
@@ -131,11 +131,11 @@ class YamlParser {
    * Parse a given input source, using the first (or only) document only
    *
    * @param  org.yaml.Input $reader
-   * @param  int $level
+   * @param  [:var] $identifiers
    * @return var
    */
-  public function parse($reader, $level= 0) {
-    $this->identifiers= [];
+  public function parse($reader, $identifiers= []) {
+    $this->identifiers= $identifiers;
     $reader->rewind();
 
     // Check for identifiers, e.g. `%YAML 1.2`
@@ -148,7 +148,7 @@ class YamlParser {
       $reader->resetLine($line);
     }
 
-    return $this->valueOf($reader, null, $level);
+    return $this->valueOf($reader, null, 0);
   }
 
   /**
@@ -156,11 +156,11 @@ class YamlParser {
    *
    * @see    https://yaml.org/spec/1.2/spec.html#id2800132
    * @param  org.yaml.Input $reader
-   * @param  int $level
+   * @param  [:var] $identifiers
    * @return iterable
    */
-  public function documents($reader, $level= 0) {
-    $this->identifiers= [];
+  public function documents($reader, $identifiers= []) {
+    $this->identifiers= $identifiers;
     $reader->rewind();
 
     // Check for identifiers, e.g. `%YAML 1.2`
@@ -171,7 +171,7 @@ class YamlParser {
     // If the first line is "---", we have a multi-document YAML source
     if ('---' === $line) {
       do {
-        yield $this->valueOf($reader, null, $level);
+        yield $this->valueOf($reader, null, 0);
 
         $line= $reader->nextLine();
         if ('...' === $line) {
@@ -182,7 +182,7 @@ class YamlParser {
       } while ('---' === $line);
     } else {
       $reader->resetLine($line);
-      yield $this->valueOf($reader, null, $level);
+      yield $this->valueOf($reader, null, 0);
     }
   }
 }

--- a/src/main/php/org/yaml/YamlParser.class.php
+++ b/src/main/php/org/yaml/YamlParser.class.php
@@ -6,10 +6,6 @@ use util\{Bytes, Date};
 class YamlParser {
   private $identifiers= [];
 
-  public function define($id, $value) {
-    
-  }
-
   /**
    * Returns an identifier. Throws an exception if the identifier is unknown.
    *
@@ -97,8 +93,6 @@ class YamlParser {
         $id= substr($value, 1, $o - 1);
         return $this->identifiers[$id]= $this->valueOf($reader, substr($value, $o + 1), $level);
       }
-    } else if ('*' === $value[0]) {
-      return $this->identifier(rtrim(substr($value, 1, strcspn($value, '#') - 1)));
     } else {
       return $this->tokenValue($reader->tokenIn($value));
     }

--- a/src/test/php/org/yaml/unittest/AbstractYamlParserTest.class.php
+++ b/src/test/php/org/yaml/unittest/AbstractYamlParserTest.class.php
@@ -11,10 +11,11 @@ abstract class AbstractYamlParserTest extends \unittest\TestCase {
    * Parse a given string and return the data
    *
    * @param  string $str
+   * @param  [:var] $identifiers
    * @return [:var]
    * @throws lang.FormatException
    */
-  protected function parse($str) {
-    return (new YamlParser())->parse(new StringInput($str));
+  protected function parse($str, $identifiers= []) {
+    return (new YamlParser())->parse(new StringInput($str), $identifiers);
   }
 }

--- a/src/test/php/org/yaml/unittest/AliasNodesTest.class.php
+++ b/src/test/php/org/yaml/unittest/AliasNodesTest.class.php
@@ -56,4 +56,20 @@ class AliasNodesTest extends AbstractYamlParserTest {
       "Override anchor: &anchor Bar\nReuse anchor: *anchor\n"
     ));
   }
+
+  #[Test]
+  public function defined_with_flow() {
+    $this->assertEquals(
+      [['x' => 1, 'y' => 2], 1],
+      $this->parse("- &CENTER { x: 1, y: 2 }\n- &TOP 1")
+    );
+  }
+
+  #[Test]
+  public function used_inside_flow() {
+    $this->assertEquals(
+      [10, 1, 'options' => [1, 10]],
+      $this->parse("- &BIG 10\n- &SMALL 1\noptions: [ *SMALL, *BIG ]")
+    );
+  }
 }

--- a/src/test/php/org/yaml/unittest/AliasNodesTest.class.php
+++ b/src/test/php/org/yaml/unittest/AliasNodesTest.class.php
@@ -31,9 +31,17 @@ class AliasNodesTest extends AbstractYamlParserTest {
     );
   }
 
-  #[Test, Expect(['class' => IllegalArgumentException::class, 'withMessage' => 'Unresolved reference "TF", have ["SS"]'])]
+  #[Test, Expect(class: IllegalArgumentException::class, withMessage: 'Unresolved reference "TF", have ["SS"]')]
   public function unresolved_reference() {
     $this->parse("- &SS Sammy Sosa\n- *TF # Does not exist\n");
+  }
+
+  #[Test]
+  public function external_reference() {
+    $this->assertEquals(
+      ['value' => $this],
+      $this->parse("value: *test\n", ['test' => $this])
+    );
   }
 
   #[Test]


### PR DESCRIPTION
This pull request adds an optional *identifiers* parameter to `parse()` and `documents()`, allowing to externally supply identifiers which can then be referenced via `*identifier` inside the YAML document.

## Example

YAML File **in.yaml**:

```yaml
parsed-from: *FILE
```

Code:

```php
use org\yaml\{FileInput, YamlParser};

$result= (new YamlParser())->parse(new FileInput($argv[1]), ['FILE' => $argv[1]]);
// ["parsed-from" => "in.yaml"]
```

## BC Break

This pull request replaces the unused *level*  parameter with *references*. Due to the BC break this introduces, this will create a major version release.