### PR TITLE
Implement "<<" merge key

### DIFF
--- a/src/main/php/org/yaml/YamlParser.class.php
+++ b/src/main/php/org/yaml/YamlParser.class.php
@@ -61,7 +61,19 @@ class YamlParser {
           $key= $value= null;
           sscanf($line, "%[^:]: %[^\r]", $key, $value);
           $key= trim(substr($key, $spaces), ' ');
-          $r[$key]= $this->valueOf($reader, $value, $spaces);
+
+          // The “<<” merge key is used to indicate that all the keys of one or more specified
+          // maps should be inserted into the current map. If the value associated with the key
+          // is a single mapping node, each of its key/value pairs is inserted into the current
+          // mapping, unless the key already exists in it.
+          if ('<<' === $key) {
+            $merge= $this->valueOf($reader, $value, $spaces);
+            foreach (0 === key($merge) ? $merge : [$merge] as $map) {
+              $r+= $map;
+            }
+          } else {
+            $r[$key]= $this->valueOf($reader, $value, $spaces);
+          }
         } else {
           $r= $this->valueOf($reader, $line, $spaces);
         }

--- a/src/test/php/org/yaml/unittest/MergeKeyTest.class.php
+++ b/src/test/php/org/yaml/unittest/MergeKeyTest.class.php
@@ -1,0 +1,57 @@
+<?php namespace org\yaml\unittest;
+
+use lang\IllegalArgumentException;
+use unittest\{Expect, Test};
+
+/**
+ * Merge Key Language-Independent Type for YAML™ Version 1.1
+ *
+ * @see   https://yaml.org/type/merge.html
+ */
+class MergeKeyTest extends AbstractYamlParserTest {
+  private $defines= [
+    'CENTER' => ['x' => 1, 'y' => 2],
+    'LEFT'   => ['x' => 0, 'y' => 2],
+    'BIG'    => ['r' => 10],
+    'SMALL'  => ['r' => 1],
+  ];
+  private $result= [
+    'x'     => 1,
+    'y'     => 2,
+    'r'     => 10,
+    'label' => 'center/big'
+  ];
+
+
+  #[Test]
+  public function explicit_keys() {
+    $this->assertEquals(
+      $this->result,
+      $this->parse("x: 1\ny: 2\nr: 10\nlabel: center/big\n", $this->defines)
+    );
+  }
+
+  #[Test]
+  public function merge_one_map() {
+    $this->assertEquals(
+      $this->result,
+      $this->parse("<< : *CENTER\nr: 10\nlabel: center/big\n", $this->defines)
+    );
+  }
+
+  #[Test]
+  public function merge_multiple_maps() {
+    $this->assertEquals(
+      $this->result,
+      $this->parse("<< : [ *CENTER, *BIG ]\nlabel: center/big\n", $this->defines)
+    );
+  }
+
+  #[Test]
+  public function override() {
+    $this->assertEquals(
+      $this->result,
+      $this->parse("<< : [ *BIG, *LEFT, *SMALL ]\nx: 1\nlabel: center/big\n", $this->defines)
+    );
+  }
+}

--- a/src/test/php/org/yaml/unittest/MergeKeyTest.class.php
+++ b/src/test/php/org/yaml/unittest/MergeKeyTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace org\yaml\unittest;
 
 use lang\IllegalArgumentException;
-use unittest\{Expect, Test};
+use unittest\{Assert, Test};
 
 /**
  * Merge Key Language-Independent Type for YAML™ Version 1.1
@@ -25,7 +25,7 @@ class MergeKeyTest extends AbstractYamlParserTest {
 
   #[Test]
   public function explicit_keys() {
-    $this->assertEquals(
+    Assert::equals(
       $this->result,
       $this->parse("x: 1\ny: 2\nr: 10\nlabel: center/big\n", $this->defines)
     );
@@ -33,7 +33,7 @@ class MergeKeyTest extends AbstractYamlParserTest {
 
   #[Test]
   public function merge_one_map() {
-    $this->assertEquals(
+    Assert::equals(
       $this->result,
       $this->parse("<< : *CENTER\nr: 10\nlabel: center/big\n", $this->defines)
     );
@@ -41,7 +41,7 @@ class MergeKeyTest extends AbstractYamlParserTest {
 
   #[Test]
   public function merge_multiple_maps() {
-    $this->assertEquals(
+    Assert::equals(
       $this->result,
       $this->parse("<< : [ *CENTER, *BIG ]\nlabel: center/big\n", $this->defines)
     );
@@ -49,7 +49,7 @@ class MergeKeyTest extends AbstractYamlParserTest {
 
   #[Test]
   public function override() {
-    $this->assertEquals(
+    Assert::equals(
       $this->result,
       $this->parse("<< : [ *BIG, *LEFT, *SMALL ]\nx: 1\nlabel: center/big\n", $this->defines)
     );

--- a/src/test/php/org/yaml/unittest/MergeKeyTest.class.php
+++ b/src/test/php/org/yaml/unittest/MergeKeyTest.class.php
@@ -1,6 +1,5 @@
 <?php namespace org\yaml\unittest;
 
-use lang\IllegalArgumentException;
 use unittest\{Assert, Test};
 
 /**

--- a/src/test/php/org/yaml/unittest/MergeKeyTest.class.php
+++ b/src/test/php/org/yaml/unittest/MergeKeyTest.class.php
@@ -21,7 +21,6 @@ class MergeKeyTest extends AbstractYamlParserTest {
     'label' => 'center/big'
   ];
 
-
   #[Test]
   public function explicit_keys() {
     Assert::equals(


### PR DESCRIPTION
Real-life example from [here](https://dmitryrck.com/how-to-use-inheritance-in-yaml-files/):

```yaml
development: &default
  adapter: postgresql
  encoding: unicode
  username: postgres
  host: db
  pool: 20
  database: app_development

test:
  <<: *default
  database: app_test
```

See https://ktomk.github.io/writing/yaml-anchor-alias-and-merge-key.html