### PR TITLE
Migrate to new testing library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         ini-values: date.timezone=Europe/Berlin
 
-    - name: Setup Problem Matchers for PHP
-      run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-
     - name: Validate composer.json and composer.lock
       run: composer validate
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,4 @@ jobs:
         echo "vendor/autoload.php" > composer.pth
 
     - name: Run test suite
-      run: sh xp-run xp.unittest.TestRunner src/test/php
+      run: sh xp-run xp.test.Runner src/test/php

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "php" : ">=7.0.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^11.0 | ^10.0 | ^9.0 | ^8.0 |^7.0 | ^6.5"
+    "xp-framework/test": "^1.0"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/src/test/php/org/yaml/unittest/AbstractInputTest.class.php
+++ b/src/test/php/org/yaml/unittest/AbstractInputTest.class.php
@@ -2,7 +2,7 @@
 
 use io\streams\{MemoryInputStream, TextReader};
 use lang\FormatException;
-use unittest\{Assert, Test, Values};
+use test\{Assert, Expect, Test, Values};
 
 /** Abstract base class for YAML Input tests */
 abstract class AbstractInputTest extends AbstractYamlParserTest {
@@ -80,22 +80,22 @@ abstract class AbstractInputTest extends AbstractYamlParserTest {
     Assert::equals('Hello', $fixture->nextLine());
   }
 
-  #[Test, Values('tokens')]
+  #[Test, Values(from: 'tokens')]
   public function token($input, $expected) {
     Assert::equals($expected, $this->newFixture()->tokenIn($input));
   }
 
-  #[Test, Values(['"hello', "'hello", '"hello \"', "'hello ''"]), Expect(class: FormatException::class, withMessage: '/Unclosed .+ quote, encountered EOF/')]
+  #[Test, Values(['"hello', "'hello", '"hello \"', "'hello ''"]), Expect(class: FormatException::class, message: '/Unclosed .+ quote, encountered EOF/')]
   public function unclosed_quote($value) {
     $this->newFixture()->tokenIn($value);
   }
 
-  #[Test, Values(['[one', '[one, []', '[one, [nested]', '[', '[[[']), Expect(class: FormatException::class, withMessage: '/Encountered EOF while parsing sequence/')]
+  #[Test, Values(['[one', '[one, []', '[one, [nested]', '[', '[[[']), Expect(class: FormatException::class, message: '/Encountered EOF while parsing sequence/')]
   public function unclosed_sequence($value) {
     $this->newFixture()->tokenIn($value);
   }
 
-  #[Test, Values(['{one: two', '{one: two, {}', '{', '{{{']), Expect(class: FormatException::class, withMessage: '/Encountered EOF while parsing map/')]
+  #[Test, Values(['{one: two', '{one: two, {}', '{', '{{{']), Expect(class: FormatException::class, message: '/Encountered EOF while parsing map/')]
   public function unclosed_map($value) {
     $this->newFixture()->tokenIn($value);
   }

--- a/src/test/php/org/yaml/unittest/AliasNodesTest.class.php
+++ b/src/test/php/org/yaml/unittest/AliasNodesTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace org\yaml\unittest;
 
 use lang\IllegalArgumentException;
-use unittest\{Assert, Expect, Test};
+use test\{Assert, Expect, Test};
 
 /**
  * 7.1 Alias Nodes
@@ -31,7 +31,7 @@ class AliasNodesTest extends AbstractYamlParserTest {
     );
   }
 
-  #[Test, Expect(class: IllegalArgumentException::class, withMessage: 'Unresolved reference "TF", have ["SS"]')]
+  #[Test, Expect(class: IllegalArgumentException::class, message: 'Unresolved reference "TF", have ["SS"]')]
   public function unresolved_reference() {
     $this->parse("- &SS Sammy Sosa\n- *TF # Does not exist\n");
   }

--- a/src/test/php/org/yaml/unittest/DocumentsTest.class.php
+++ b/src/test/php/org/yaml/unittest/DocumentsTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace org\yaml\unittest;
 
 use org\yaml\{StringInput, YamlParser};
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class DocumentsTest {
 

--- a/src/test/php/org/yaml/unittest/EmptyNodesTest.class.php
+++ b/src/test/php/org/yaml/unittest/EmptyNodesTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace org\yaml\unittest;
 
-use unittest\{Assert, Ignore, Test};
+use test\{Assert, Ignore, Test};
 
 /**
  * 7.2 Empty Nodes

--- a/src/test/php/org/yaml/unittest/FlowCollectionsTest.class.php
+++ b/src/test/php/org/yaml/unittest/FlowCollectionsTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace org\yaml\unittest;
 
 use lang\FormatException;
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 /**
  * 7.4. Flow Collection Styles

--- a/src/test/php/org/yaml/unittest/FlowScalarsTest.class.php
+++ b/src/test/php/org/yaml/unittest/FlowScalarsTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace org\yaml\unittest;
 
 use lang\FormatException;
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 
 /**
  * 7.3. Flow Scalar Styles

--- a/src/test/php/org/yaml/unittest/MergeKeyTest.class.php
+++ b/src/test/php/org/yaml/unittest/MergeKeyTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace org\yaml\unittest;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 /**
  * Merge Key Language-Independent Type for YAML™ Version 1.1

--- a/src/test/php/org/yaml/unittest/ReaderInputTest.class.php
+++ b/src/test/php/org/yaml/unittest/ReaderInputTest.class.php
@@ -2,7 +2,7 @@
 
 use io\streams\{InputStream, MemoryInputStream, TextReader};
 use org\yaml\ReaderInput;
-use unittest\Test;
+use test\Test;
 
 /** Tests the "Reader" input implementation */
 class ReaderInputTest extends AbstractInputTest {

--- a/src/test/php/org/yaml/unittest/YamlParserTest.class.php
+++ b/src/test/php/org/yaml/unittest/YamlParserTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\IllegalArgumentException;
 use org\yaml\YamlParser;
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 use util\{Bytes, Date};
 
 class YamlParserTest extends AbstractYamlParserTest {


### PR DESCRIPTION
See https://github.com/xp-framework/rfc/issues/344 and https://github.com/xp-framework/test. Migrated automatically, one missing import for `Expect` added manually.