### PR TITLE
Support quoted and typed keys

### DIFF
--- a/src/main/php/org/yaml/Input.class.php
+++ b/src/main/php/org/yaml/Input.class.php
@@ -176,7 +176,7 @@ abstract class Input {
    * @param  string $end
    * @return var[]
    */
-  private function token(&$in, &$offset, $end= '#') {
+  public function token(&$in, &$offset, $end= '#') {
     $l= strlen($in);
     $offset+= strspn($in, ' ', $offset);
     if ($offset >= $l) return null;

--- a/src/main/php/org/yaml/Input.class.php
+++ b/src/main/php/org/yaml/Input.class.php
@@ -186,7 +186,7 @@ abstract class Input {
 
     $c= $in[$offset];
     if ('"' === $c) {
-      $offset+= 1;
+      $offset++;
       $string= '';
       do {
         $p= strcspn($in, '\\"', $offset);
@@ -206,7 +206,7 @@ abstract class Input {
         $offset+= $p;
       } while (true);
     } else if ("'" === $c) {
-      $offset+= 1;
+      $offset++;
       $string= '';
       do {
         $p= strcspn($in, "'", $offset);
@@ -231,7 +231,7 @@ abstract class Input {
       $in.= $this->nextLine();
       return $this->token($in, $offset, $end);
     } else if ('*' === $c) {
-      $offset+= 1;
+      $offset++;
       $p= strcspn($in, $end, $offset);
       $literal= trim(substr($in, $offset, $p));
       $offset+= strlen($literal);

--- a/src/main/php/org/yaml/Input.class.php
+++ b/src/main/php/org/yaml/Input.class.php
@@ -270,10 +270,10 @@ abstract class Input {
       $offset++;
       return $c;
     } else if (0 === substr_compare($in, '!!', $offset, 2)) {
-      $p= strcspn($in, ' ', $offset);
+      $p= strcspn($in, ' '.$end, $offset);
       $tag= substr($in, $offset + 2, $p - 2);
       $offset+= $p + 1;
-      if ($offset >= $l) return [$tag, null];
+      if ($offset >= $l || $end === $in[$offset]) return [$tag, null];
       $token= $this->token($in, $offset, $end);
       return [$tag, $token[1]];
     } else {

--- a/src/main/php/org/yaml/YamlParser.class.php
+++ b/src/main/php/org/yaml/YamlParser.class.php
@@ -58,42 +58,10 @@ class YamlParser {
             $r[$key]= $this->valueOf($reader, substr($line, $spaces + 2), $spaces);
           }
         } else if (!strpos('#!?{[', $line[$spaces]) && strpos($line, ':')) {
-
-          // Parse keys and values, including string handling
-          if ('"' === $line[$spaces]) {
-            $start= $spaces + 1;
-            $key= '';
-
-            dq: $p= strcspn($line, '\\"', $start);
-            if ('\\' === $line[$start + $p]) {
-              $key.= substr($line, $start, $p).'"';
-              $start+= $p + 2;
-              goto dq;
-            }
-
-            $key= trim($key.substr($line, $start, $p));
-            $start+= $p;
-            $start+= strcspn($line, ':', $start);
-          } else if ("'" === $line[$spaces]) {
-            $start= $spaces + 1;
-            $key= '';
-
-            sq: $p= strcspn($line, "'", $start);
-            if ("'" === $line[$start + $p + 1] ?? null) {
-              $key.= substr($line, $start, $p)."'";
-              $start+= $p + 2;
-              goto sq;
-            }
-
-            $key= trim($key.substr($line, $start, $p));
-            $start+= $p;
-            $start+= strcspn($line, ':', $start);
-          } else {
-            $p= strcspn($line, ':', $spaces);
-            $key= trim(substr($line, $spaces, $p));
-            $start= $spaces + $p;
-          }
-          $value= $start + 2 >= $l ? null : substr($line, $start + 2);
+          $offset= $spaces;
+          $key= trim($this->tokenValue($reader->token($line, $offset, ':')));
+          $offset+= strcspn($line, ':', $offset) + 2;
+          $value= $offset >= $l ? null : substr($line, $offset);
 
           // The “<<” merge key is used to indicate that all the keys of one or more specified
           // maps should be inserted into the current map. If the value associated with the key

--- a/src/main/php/org/yaml/YamlParser.class.php
+++ b/src/main/php/org/yaml/YamlParser.class.php
@@ -60,15 +60,40 @@ class YamlParser {
         } else if (!strpos('#!?{[', $line[$spaces]) && strpos($line, ':')) {
 
           // Parse keys and values, including string handling
-          if ('"' === $line[$spaces] || "'" === $line[$spaces]) {
-            $p= strcspn($line, $line[$spaces], $spaces + 1);
-            $key= trim(substr($line, $spaces + 1, $p));
-            $p+= strcspn($line, ':', $spaces + 1 + $p);
+          if ('"' === $line[$spaces]) {
+            $start= $spaces + 1;
+            $key= '';
+
+            dq: $p= strcspn($line, '\\"', $start);
+            if ('\\' === $line[$start + $p]) {
+              $key.= substr($line, $start, $p).'"';
+              $start+= $p + 2;
+              goto dq;
+            }
+
+            $key= trim($key.substr($line, $start, $p));
+            $start+= $p;
+            $start+= strcspn($line, ':', $start);
+          } else if ("'" === $line[$spaces]) {
+            $start= $spaces + 1;
+            $key= '';
+
+            sq: $p= strcspn($line, "'", $start);
+            if ("'" === $line[$start + $p + 1] ?? null) {
+              $key.= substr($line, $start, $p)."'";
+              $start+= $p + 2;
+              goto sq;
+            }
+
+            $key= trim($key.substr($line, $start, $p));
+            $start+= $p;
+            $start+= strcspn($line, ':', $start);
           } else {
             $p= strcspn($line, ':', $spaces);
             $key= trim(substr($line, $spaces, $p));
+            $start= $spaces + $p;
           }
-          $value= $spaces + $p + 2 >= $l ? null : substr($line, $spaces + $p + 2);
+          $value= $start + 2 >= $l ? null : substr($line, $start + 2);
 
           // The “<<” merge key is used to indicate that all the keys of one or more specified
           // maps should be inserted into the current map. If the value associated with the key

--- a/src/main/php/org/yaml/YamlParser.class.php
+++ b/src/main/php/org/yaml/YamlParser.class.php
@@ -58,9 +58,17 @@ class YamlParser {
             $r[$key]= $this->valueOf($reader, substr($line, $spaces + 2), $spaces);
           }
         } else if (!strpos('#!?{[', $line[$spaces]) && strpos($line, ':')) {
-          $key= $value= null;
-          sscanf($line, "%[^:]: %[^\r]", $key, $value);
-          $key= trim(substr($key, $spaces), ' ');
+
+          // Parse keys and values, including string handling
+          if ('"' === $line[$spaces] || "'" === $line[$spaces]) {
+            $p= strcspn($line, $line[$spaces], $spaces + 1);
+            $key= trim(substr($line, $spaces + 1, $p));
+            $p+= strcspn($line, ':', $spaces + 1 + $p);
+          } else {
+            $p= strcspn($line, ':', $spaces);
+            $key= trim(substr($line, $spaces, $p));
+          }
+          $value= $spaces + $p + 2 >= $l ? null : substr($line, $spaces + $p + 2);
 
           // The “<<” merge key is used to indicate that all the keys of one or more specified
           // maps should be inserted into the current map. If the value associated with the key

--- a/src/main/php/org/yaml/YamlParser.class.php
+++ b/src/main/php/org/yaml/YamlParser.class.php
@@ -57,26 +57,31 @@ class YamlParser {
           } else {
             $r[$key]= $this->valueOf($reader, substr($line, $spaces + 2), $spaces);
           }
-        } else if (!strpos('#!?{[', $line[$spaces]) && strpos($line, ':')) {
-          $offset= $spaces;
-          $key= trim($this->tokenValue($reader->token($line, $offset, ':')));
-          $offset+= strcspn($line, ':', $offset) + 2;
-          $value= $offset >= $l ? null : substr($line, $offset);
-
-          // The “<<” merge key is used to indicate that all the keys of one or more specified
-          // maps should be inserted into the current map. If the value associated with the key
-          // is a single mapping node, each of its key/value pairs is inserted into the current
-          // mapping, unless the key already exists in it.
-          if ('<<' === $key) {
-            $merge= $this->valueOf($reader, $value, $spaces);
-            foreach (0 === key($merge) ? $merge : [$merge] as $map) {
-              $r+= $map;
-            }
-          } else {
-            $r[$key]= $this->valueOf($reader, $value, $spaces);
-          }
         } else {
-          $r= $this->valueOf($reader, $line, $spaces);
+          $offset= $spaces;
+          $token= $reader->token($line, $offset, ':');
+
+          // After reading the token, if we encounter a colon, construct a map
+          if (false === ($p= strpos($line, ':', $offset))) {
+            $r= $this->tokenValue($token);
+          } else {
+            $key= trim($this->tokenValue($token));
+            $p++;
+            $value= $p + 1 < $l ? substr($line, $p + strspn($line, ' ', $p)) : null;
+
+            // The “<<” merge key is used to indicate that all the keys of one or more specified
+            // maps should be inserted into the current map. If the value associated with the key
+            // is a single mapping node, each of its key/value pairs is inserted into the current
+            // mapping, unless the key already exists in it.
+            if ('<<' === $key) {
+              $merge= $this->valueOf($reader, $value, $spaces);
+              foreach (0 === key($merge) ? $merge : [$merge] as $map) {
+                $r+= $map;
+              }
+            } else {
+              $r[$key]= $this->valueOf($reader, $value, $spaces);
+            }
+          }
         }
 
       } while (null !== ($line= $reader->nextLine()));

--- a/src/test/php/org/yaml/unittest/EmptyNodesTest.class.php
+++ b/src/test/php/org/yaml/unittest/EmptyNodesTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace org\yaml\unittest;
 
-use test\{Assert, Ignore, Test};
+use test\{Assert, Test};
 
 /**
  * 7.2 Empty Nodes
@@ -18,7 +18,7 @@ class EmptyNodesTest extends AbstractYamlParserTest {
     Assert::equals(['key' => null], $this->parse('key: '));
   }
 
-  #[Test, Ignore('Key types not yet supported')]
+  #[Test]
   public function empty_string_key() {
     Assert::equals(['' => 'value'], $this->parse('!!str : value'));
   }

--- a/src/test/php/org/yaml/unittest/YamlParserTest.class.php
+++ b/src/test/php/org/yaml/unittest/YamlParserTest.class.php
@@ -131,7 +131,7 @@ class YamlParserTest extends AbstractYamlParserTest {
     );
   }
 
-  #[Test, Values([['key', 'key'], ['"key"', 'key'], ["'key'", 'key'], ['key b', 'key b'], ['"key:"', 'key:'], ['"key \"b\""', 'key "b"'], ["'key ''b'''", "key 'b'"]])]
+  #[Test, Values([['key', 'key'], ['"key"', 'key'], ["'key'", 'key'], ['key b', 'key b'], ['"key:"', 'key:'], ['"key::b"', 'key::b'], ['"key \"b\""', 'key "b"'], ["'key ''b'''", "key 'b'"]])]
   public function string_keys($declaration, $expected) {
     Assert::equals([$expected => 1], $this->parse("{$declaration}: 1"));
   }

--- a/src/test/php/org/yaml/unittest/YamlParserTest.class.php
+++ b/src/test/php/org/yaml/unittest/YamlParserTest.class.php
@@ -131,7 +131,7 @@ class YamlParserTest extends AbstractYamlParserTest {
     );
   }
 
-  #[Test, Values([['key', 'key'], ['"key"', 'key'], ["'key'", 'key'], ['key b', 'key b'], ['"key:"', 'key:'], ['"key::b"', 'key::b'], ['"key \"b\""', 'key "b"'], ["'key ''b'''", "key 'b'"]])]
+  #[Test, Values([['key', 'key'], ['"key"', 'key'], ["'key'", 'key'], ['key b', 'key b'], ['"key:"', 'key:'], ['"key::b"', 'key::b'], ['"key \"b\""', 'key "b"'], ["'key ''b'''", "key 'b'"], ['!!str key', 'key']])]
   public function string_keys($declaration, $expected) {
     Assert::equals([$expected => 1], $this->parse("{$declaration}: 1"));
   }

--- a/src/test/php/org/yaml/unittest/YamlParserTest.class.php
+++ b/src/test/php/org/yaml/unittest/YamlParserTest.class.php
@@ -131,12 +131,9 @@ class YamlParserTest extends AbstractYamlParserTest {
     );
   }
 
-  #[Test]
-  public function string_keys() {
-    Assert::equals(
-      ['one' => 1, 'two' => 2, 'three' => 3, '4th element' => 4, '5th:' => 5],
-      $this->parse("one: 1\n\"two\": 2\n'three': 3\n4th element: 4\n\"5th:\": 5")
-    );
+  #[Test, Values([['key', 'key'], ['"key"', 'key'], ["'key'", 'key'], ['key b', 'key b'], ['"key:"', 'key:'], ['"key \"b\""', 'key "b"'], ["'key ''b'''", "key 'b'"]])]
+  public function string_keys($declaration, $expected) {
+    Assert::equals([$expected => 1], $this->parse("{$declaration}: 1"));
   }
 
   #[Test]

--- a/src/test/php/org/yaml/unittest/YamlParserTest.class.php
+++ b/src/test/php/org/yaml/unittest/YamlParserTest.class.php
@@ -132,6 +132,14 @@ class YamlParserTest extends AbstractYamlParserTest {
   }
 
   #[Test]
+  public function string_keys() {
+    Assert::equals(
+      ['one' => 1, 'two' => 2, 'three' => 3, '4th element' => 4, '5th:' => 5],
+      $this->parse("one: 1\n\"two\": 2\n'three': 3\n4th element: 4\n\"5th:\": 5")
+    );
+  }
+
+  #[Test]
   public function mapping_scalars_to_sequences() {
     Assert::equals(
       [


### PR DESCRIPTION
All of the following are equivalent:

```yaml
key: value
"key": value
'key': value
!!str key: value
```

See https://stackoverflow.com/a/34009604